### PR TITLE
Added Brazilian Portuguese

### DIFF
--- a/src/Components/KeyBoard.jsx
+++ b/src/Components/KeyBoard.jsx
@@ -19,6 +19,7 @@ function KeyBoard(props) {
         'a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', ';', '.',
         'z', 'x', 'c', 'v', 'b', 'n', 'm', ',', '.'
     ];
+
     const ukranianArr = [
         'й', 'ц', 'у', 'к', 'е', 'н', 'г', 'ш', 'щ', 'з', 'х', 'ї',
         'ф', 'і', 'в', 'а', 'п', 'р', 'о', 'л', 'д', 'ж', 'є',
@@ -29,6 +30,13 @@ function KeyBoard(props) {
         'ф', 'ы', 'в', 'а', 'п', 'р', 'о', 'л', 'д', 'ж', 'э',
         'я', 'ч', 'с', 'м', 'и', 'т', 'ь', 'б', 'ю'
     ];
+
+    const portugueseArr = [
+        'q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p',
+        'a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'ç', ';',
+        'z', 'x', 'c', 'v', 'b', 'n', 'm', ',', '.'
+    ];
+
     let keyboardArr;
     const capslockArr = [...numbersArr, ...englishArr.map(char => char.toUpperCase())];
     switch (props.language) {
@@ -46,6 +54,9 @@ function KeyBoard(props) {
             break;
         case "russian":
             keyboardArr = [...numbersArr, ...russianArr];
+            break;
+        case "portuguese":
+            keyboardArr = [...numbersArr, ...portugueseArr];
             break;
         default:
             keyboardArr = [];

--- a/src/Components/KeyBoardLanguage.jsx
+++ b/src/Components/KeyBoardLanguage.jsx
@@ -26,9 +26,12 @@ function KeyBoardLanguage(props) {
       case "russian":
         setLanguage("russian");
         break;
-        case "ukranian":
-          setLanguage("ukranian");
-          break;
+      case "ukranian":
+        setLanguage("ukranian");
+        break;
+      case "portuguese":
+        setLanguage("portuguese");
+        break;
       default:
         setLanguage([]);
     }
@@ -36,13 +39,14 @@ function KeyBoardLanguage(props) {
   return (
     <div className="language-and-icons">
       <select className="chooseLanguage" onChange={handleChange}>
-      <option value="english">English</option>
+        <option value="english">English</option>
         <option value="hebrew">עברית</option>
         <option value="arabic">عربيه</option>
         <option value="ukranian">українська</option>
         <option value="russian">русский</option>
+        <option value="portuguese">Português</option>
       </select>
-      {props.isEmojiActive ? (    
+      {props.isEmojiActive ? (
         <FaKeyboard className="icon" id="kyboard-icon" onClick={props.changeState} />
       ) : (
         <button className='icon' onClick={props.changeState}>

--- a/src/Components/virtualKeyBoard.jsx
+++ b/src/Components/virtualKeyBoard.jsx
@@ -17,6 +17,7 @@ function VirtualKeyBoard() {
     "أكتب هنا",
     "друкуйте тут",
     "напечатайте здесь",
+    "digite aqui",
   ];
   const [placeholder, setPlaceHolder] = useState("type here");
   const [language, setLanguage] = useState("english");
@@ -45,6 +46,9 @@ function VirtualKeyBoard() {
         break;
       case "russian":
         setPlaceHolder(placeholders[4]);
+        break;
+      case "portuguese":
+        setPlaceHolder(placeholders[5]);
         break;
       default:
         setPlaceHolder(placeholders[0]);


### PR DESCRIPTION
Hello @chavi362.
I added the Portuguese (Brazilian) language.
It is very similar to the English keyboard.
The difference is that Portuguese has many graphic accents (´, ~, ^, `).
On physical keyboards, these graphic accents accompany other symbols and can be accessed with the SHIFT + KEY combination.
We can think about doing something similar (to access graphic accents) for Portuguese and other Latin languages.